### PR TITLE
Exit if connection fails

### DIFF
--- a/rplugin/python3/discord/__init__.py
+++ b/rplugin/python3/discord/__init__.py
@@ -55,7 +55,11 @@ class DiscordPlugin(object):
                 return
             self.discord = Discord(client_id, reconnect_threshold)
             with handle_lock(self):
-                self.discord.connect()
+                try:
+                    self.discord.connect()
+                except:
+                    self.log_debug("connection failed")
+                    return
                 self.log_debug("init")
             if self.locked:
                 return


### PR DESCRIPTION
Instead of exiting with an error which is displayed in vim, immediately stops if we could not connect to Discord (most likely when there's is no network)