### PR TITLE
Fix "no notification handler registered"

### DIFF
--- a/autoload/discord.vim
+++ b/autoload/discord.vim
@@ -22,18 +22,24 @@ function! discord#GetProjectDir(buffer)
 endfunction
 
 function! discord#LogDebug(message, trace)
-  call add(g:discord_trace, a:trace)
+  if a:trace != v:null
+    call add(g:discord_trace, a:trace)
+  endif
   if g:discord_log_debug
     echomsg '[discord] ' . a:message
   endif
 endfunction
 
 function! discord#LogWarn(message, trace)
-  call add(g:discord_trace, a:trace)
+  if a:trace != v:null
+    call add(g:discord_trace, a:trace)
+  endif
   echohl WarningMsg | echomsg '[discord] ' . a:message | echohl None
 endfunction
 
 function! discord#LogError(message, trace)
-  call add(g:discord_trace, a:trace)
+  if a:trace != v:null
+    call add(g:discord_trace, a:trace)
+  endif
   echohl ErrorMsg | echomsg '[discord] ' . a:message | echohl None
 endfunction

--- a/rplugin/python3/discord/__init__.py
+++ b/rplugin/python3/discord/__init__.py
@@ -40,7 +40,7 @@ class DiscordPlugin(object):
         self.lasttimestamp = int(time())
         self.cbtimer = None
 
-    @neovim.autocmd("VimEnter", "*")
+    @neovim.autocmd("VimEnter", "*", sync=True)
     def on_vimenter(self):
         self.blacklist = [
             re.compile(x) for x in self.vim.vars.get("discord_blacklist")
@@ -48,7 +48,7 @@ class DiscordPlugin(object):
         self.fts_blacklist = self.vim.vars.get("discord_fts_blacklist")
         self.fts_whitelist = self.vim.vars.get("discord_fts_whitelist")
 
-    @neovim.autocmd("BufEnter", "*")
+    @neovim.autocmd("BufEnter", "*", sync=True)
     def on_bufenter(self):
         if self.activate != 0:
             self.update_presence()


### PR DESCRIPTION
This is an attempt to fix the `autocmd` handlers inspired by a comment in [Semshi](https://github.com/numirias/semshi/blob/master/rplugin/python3/semshi/plugin.py#L71-L72):
> Must not be async here because we have to make sure that switching the
> buffer handler is completed before other events are handled.

neovim/pynvim#341 suggests that the issue might be caused by a race condition.

P.S. I also added some checks to the log functions to avoid filling `g:discord_trace` with `v:null`.

---

closes #18, closes #21

/cc @Jerrynicki, @DrBlueFall, @jcarter777, @PlanetAaron, @samedamci, @Awlexus