### PR TITLE
Add instructions to uninstall discord.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ call dein#add('aurieh/discord.nvim')
 ```
 To finish things off, call `:UpdateRemotePlugins` and restart Neovim.
 
+## Uninstall
+1. Remove the line used to add the Plugin in your `init.vim`
+2. Run `:UpdateRemotePlugins` inside of vim.
+
 # TODO
 - [ ] Multiple clients: wait for lock
 - [X] Rewrite the client in pure python, no cffi


### PR DESCRIPTION
I had to dig through the docs of nvim to figure out how to uninstall discord.nvim properly.
Just removing it from my `.vimrc` was giving me errors every time I opened nvim.