### PR TITLE
Add project URL to rich presence

### DIFF
--- a/doc/discord.txt
+++ b/doc/discord.txt
@@ -14,6 +14,7 @@ CONTENTS                                                     *discord-contents*
       2.1.2 g:discord_clientid                             |g:discord_clientid|
       2.1.3 g:discord_reconnect_threshold       |g:discord_reconnect_threshold|
       2.1.4 g:discord_log_debug                           |g:discord_log_debug|
+      2.1.5 g:discord_project_url                       |g:discord_project_url|
     2.2 Commands                                             |discord-commands|
       2.2.1 DiscordUpdatePresence                       |DiscordUpdatePresence|
 
@@ -61,11 +62,18 @@ g:discord_log_debug                                       *g:discord_log_debug*
 
 g:discord_blacklist                                       *g:discord_blacklist*
 
-    Type: List
-    Default: []
+    Type: |List|
+    Default: `[]`
 
     List of regexes that are matched against all filenames. If one matches,
     the buffer is ignored.
+
+g:discord_project_url                                   *g:discord_project_url*
+
+    Type: |String|
+
+    The project URL to show in the rich presence. No URL will be shown if
+    this variable is unset or empty.
 
 -------------------------------------------------------------------------------
 COMMANDS                                                     *discord-commands*

--- a/rplugin/python3/discord/__init__.py
+++ b/rplugin/python3/discord/__init__.py
@@ -47,6 +47,7 @@ class DiscordPlugin(object):
         ]
         self.fts_blacklist = self.vim.vars.get("discord_fts_blacklist")
         self.fts_whitelist = self.vim.vars.get("discord_fts_whitelist")
+        self.project_url = self.vim.vars.get("discord_project_url")
 
     @neovim.autocmd("BufEnter", "*", sync=True)
     def on_bufenter(self):
@@ -63,6 +64,10 @@ class DiscordPlugin(object):
                 "large_image": "neovim"
             }
             self.activity["timestamps"] = {"start": int(time())}
+            if self.project_url:
+                self.activity["buttons"] = [
+                    {"label": "Open project URL", "url": self.project_url}
+                ]
         if not self.lock:
             self.lock = PidLock(join(get_tempdir(), "dnvim_lock"))
         if self.locked:


### PR DESCRIPTION
This pull request adds the ability to display the project URL as a button in the rich presence.
For some bizarre reason, the button doesn't work for yourself on Discord but it does for others.