### PR TITLE
Fix missing initialization of `DiscordPlugin.project_url`

### DIFF
--- a/rplugin/python3/discord/__init__.py
+++ b/rplugin/python3/discord/__init__.py
@@ -32,6 +32,7 @@ class DiscordPlugin(object):
         self.blacklist = []
         self.fts_blacklist = []
         self.fts_whitelist = []
+        self.project_url = None
         # Ratelimits
         self.lock = None
         self.locked = False


### PR DESCRIPTION
When running from the BufEnter-hook, the plugin would crash
with:

```
Error detected while processing function remote#define#request:
line    2:
Error invoking '/home/X/.config/nvim/plugged/discord.nvim/rplugin/python3/discord:autocmd:BufEnter:*' on channel 4 (python3-rplugin-host):
error caught in request handler '/home/X/.config/nvim/plugged/discord.nvim/rplugin/python3/discord:autocmd:BufEnter:* []':
Traceback (most recent call last):
  File "/home/X/.config/nvim/plugged/discord.nvim/rplugin/python3/discord/__init__.py", line 55, in on_bufenter
    self.update_presence()
  File "/home/X/.config/nvim/plugged/discord.nvim/rplugin/python3/discord/__init__.py", line 67, in update_presence
    if self.project_url:
AttributeError: 'DiscordPlugin' object has no attribute 'project_url'
```

This initializes `project_url` in `DiscordPlugin.__init__`.

Fixes #41.