### PR TITLE
discord_log_warn variable

### DIFF
--- a/autoload/discord.vim
+++ b/autoload/discord.vim
@@ -34,7 +34,9 @@ function! discord#LogWarn(message, trace)
   if a:trace != v:null
     call add(g:discord_trace, a:trace)
   endif
-  echohl WarningMsg | echomsg '[discord] ' . a:message | echohl None
+  if g:discord_log_warn
+      echohl WarningMsg | echomsg '[discord] ' . a:message | echohl None
+  endif
 endfunction
 
 function! discord#LogError(message, trace)

--- a/doc/discord.txt
+++ b/doc/discord.txt
@@ -60,6 +60,13 @@ g:discord_log_debug                                       *g:discord_log_debug*
 
     Enables or disables debug logging.
 
+g:discord_log_warn                                        *g:discord_log_warn*
+
+    Type: |Number|
+    Default: `1`
+
+    Enables or disables warning logging.
+
 g:discord_blacklist                                       *g:discord_blacklist*
 
     Type: |List|

--- a/doc/discord.txt
+++ b/doc/discord.txt
@@ -14,7 +14,8 @@ CONTENTS                                                     *discord-contents*
       2.1.2 g:discord_clientid                             |g:discord_clientid|
       2.1.3 g:discord_reconnect_threshold       |g:discord_reconnect_threshold|
       2.1.4 g:discord_log_debug                           |g:discord_log_debug|
-      2.1.5 g:discord_project_url                       |g:discord_project_url|
+      2.1.5 g:discord_log_warn                             |g:discord_log_warn|
+      2.1.6 g:discord_project_url                       |g:discord_project_url|
     2.2 Commands                                             |discord-commands|
       2.2.1 DiscordUpdatePresence                       |DiscordUpdatePresence|
 

--- a/plugin/discord.vim
+++ b/plugin/discord.vim
@@ -23,6 +23,9 @@ endif
 if !exists('g:discord_log_debug')
   let g:discord_log_debug = 0
 endif
+if !exists('g:discord_log_warn')
+  let g:discord_log_warn = 1
+endif
 if !exists('g:discord_blacklist')
   let g:discord_blacklist = []
 endif


### PR DESCRIPTION
Hi,

this pull request adds support for disabling warning logs, similarly to the `discord_log_debug` variable, via the variable `discord_log_warn`. By default warning logs are enabled, just like on the current master branch. My personal usecase for this is to disable warnings like "local discord client not found" since I might not always be running Discord in the background while using Vim. I added docs and set the variable similarly to `discord_log_debug`, let me know if I missed anything.